### PR TITLE
Add detailed project backlog for LLM selection strategy

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -1,0 +1,52 @@
+# PROJECT BACKLOG — llm-selection
+
+This project aims to support strategic model selection for LLM tasks. It will track model capabilities, reasoning depth, rate limits, file support, access type (API/local), and usage strategies.
+
+---
+
+## ✅ Core Goals
+
+- Catalog available models (GPT-4o, Claude, Gemini, Perplexity, local models)
+- Track API access methods, rate limits, pricing, latency, reliability
+- Differentiate models by reasoning strength vs generation speed
+- Record model-specific prompt adaptation patterns
+- Design a lightweight routing logic for task-type-to-model mapping
+- Enable reviewer prompts to assess model output reliability
+- Plan for multi-model evaluation loops (e.g., Grok + Claude + GPT-4o)
+- Begin evaluation logging for performance and failures
+
+---
+
+## 🧠 Key Ideas to Track
+
+- Reasoning models vs generative models: how to choose
+- Structured vs unstructured prompt input
+- Task classification: research, summarization, synthesis, validation
+- Local quantized model usage and constraints (e.g., llama.cpp, Ollama)
+- Router design: file-based input → task → model(s) → reviewer loop
+- Use of assistant-agent separation (router, reviewer, executor)
+- Explore how to collect model performance data over time
+- Evaluate when to use search vs static LLM
+- Decision trees, scorecards, or rule-sets for model choice
+
+---
+
+## 🧪 Suggested Experiments
+
+- Run identical prompts across GPT-4o, Claude Opus, Gemini Pro
+- Use reviewer prompt to evaluate each output
+- Compare search-enabled vs search-disabled runs
+- Benchmark against latency, reasoning quality, hallucination frequency
+
+---
+
+## 📥 Tasks (Initial)
+
+- [ ] Create `models.md` for cataloging available LLMs
+- [ ] Add `routing-strategy.md` to outline logic by task type
+- [ ] Prepare reviewer prompt set in `reviewer-prompts.md`
+- [ ] Design and test a selection prompt (e.g., “Which model should I use for X?”)
+
+---
+
+> You can move any of these items into GitHub Issues or Projects if needed. This backlog will grow as other repos are integrated.

--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -3,6 +3,23 @@
 This file serves as the **complete strategic record** for the `llm-selection` project.  
 It contains all relevant ideas, insights, plans, and instructions discussed — **nothing omitted**.
 
+## 📋 Table of Contents
+
+- [Project Purpose](#-project-purpose)
+- [Key Goals](#-key-goals)
+- [Core Components](#-core-components)
+  - [Model Capability Tracker](#1-model-capability-tracker)
+  - [Routing Logic](#2-routing-logic)
+  - [Reviewer Agent](#3-reviewer-agent)
+  - [Prompt Adaptation Patterns](#4-prompt-adaptation-patterns)
+  - [Evaluation Workflows](#5-evaluation-workflows)
+  - [Task Classifier](#6-task-classifier-future)
+- [Roles & Agents](#-roles--agents)
+- [Key Insights & Strategy Notes](#-key-insights--strategy-notes)
+- [Experiments](#-experiments)
+- [Tasks (Open)](#-tasks-open)
+- [Notes](#-notes)
+
 ---
 
 ## ✅ Project Purpose
@@ -13,15 +30,25 @@ Design and maintain a system for **selecting, routing, and evaluating large lang
 
 ## 🔹 Key Goals
 
+### Catalog & Capabilities
+
 - Create a structured **catalog of available LLMs** (hosted + local)
 - Track model capabilities: reasoning, generation, summarization, speed, latency
 - Track access methods: OpenAI, Claude, Gemini, Grok, local APIs, etc.
-- Document prompt adaptation needs for different models
+
+### Routing & Logic
+
 - Develop a model selection and routing logic (manual + automated)
 - Enable task-based model decision-making using clear rules
+- Document prompt adaptation needs for different models
+
+### Evaluation & Feedback
+
 - Design **reviewer prompts** to evaluate model output reliability and completeness
 - Implement multi-model feedback loops: compare answers, escalate, route to reviewer
 - Prepare for eventual automation and integration into assistant/agent systems
+
+---
 
 ---
 
@@ -29,11 +56,15 @@ Design and maintain a system for **selecting, routing, and evaluating large lang
 
 ### 1. Model Capability Tracker
 
+*See detailed design in [models.md](models.md)*
+
 - Name, provider, access type (API/local), rate limits, cost structure
 - Token/window limits, search capability, file input support
 - Update history, reliability patterns, reasoning depth classification
 
 ### 2. Routing Logic
+
+*See detailed design in [routing-strategy.md](routing-strategy.md)*
 
 - Task-to-model mapping table or logic flow
 - Conditional decision-making (e.g., if search needed, use X; if local, use Y)
@@ -41,11 +72,15 @@ Design and maintain a system for **selecting, routing, and evaluating large lang
 
 ### 3. Reviewer Agent
 
+*See detailed design in [reviewer-prompts.md](reviewer-prompts.md)*
+
 - Prompt templates for reviewing output quality, coherence, hallucination risk
 - Scoring guidelines and structured review format
 - Cross-model comparison prompts
 
 ### 4. Prompt Adaptation Patterns
+
+*See detailed implementation in [prompt-patterns.md](prompt-patterns.md) (planned)*
 
 - Variants needed for models that require different formatting (e.g., Claude XML tags)
 - Self-evaluation trigger prompts ("explain how you understood this before answering")
@@ -53,14 +88,20 @@ Design and maintain a system for **selecting, routing, and evaluating large lang
 
 ### 5. Evaluation Workflows
 
+*See detailed workflows in [evaluation-flows.md](evaluation-flows.md) (planned)*
+
 - Run same prompt across multiple models
 - Capture outputs + reviewer evaluation
 - Score responses on reasoning, hallucination risk, formatting, insight quality
 
 ### 6. Task Classifier (Future)
 
+*See design plans in [task-classifier.md](task-classifier.md) (planned)*
+
 - Classify user requests into task types: research, summarization, validation, generation
 - Use classification to trigger routing decisions
+
+---
 
 ---
 
@@ -79,9 +120,9 @@ Design and maintain a system for **selecting, routing, and evaluating large lang
 - **Model selection is not static**: capabilities evolve rapidly, so selection logic must be easily editable
 - Reasoning models (GPT-4o, Claude Opus) often required for synthesis, logic, ambiguity
 - Generation-first models (e.g. Gemini Pro) may be better for formatting, templating, speed
-- **Reviewers are essential**: many LLMs produce superficially plausible but flawed answers
+- Reviewers are essential: many LLMs produce superficially plausible, but flawed answers
 - Model hallucination is often subtle; detecting it must be part of the process
-- **Two-way flow with agents like Copilot** is critical (copilot executes, LLMs generate)
+- **Two-way flow with agents like Copilot** is critical (e.g., Copilot asks LLM → LLM generates solution → Copilot verifies and executes)
 - **File- and folder-based context** is more scalable than prompt text alone
 - Local quantized models (e.g., via Ollama, llama.cpp) are viable but must be benchmarked
 - Cost/rate limits can be offset by chaining: cheap model for draft, powerful model for polish

--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -1,52 +1,126 @@
 # PROJECT BACKLOG — llm-selection
 
-This project aims to support strategic model selection for LLM tasks. It will track model capabilities, reasoning depth, rate limits, file support, access type (API/local), and usage strategies.
+This file serves as the **complete strategic record** for the `llm-selection` project.  
+It contains all relevant ideas, insights, plans, and instructions discussed — **nothing omitted**.
 
 ---
 
-## ✅ Core Goals
+## ✅ Project Purpose
 
-- Catalog available models (GPT-4o, Claude, Gemini, Perplexity, local models)
-- Track API access methods, rate limits, pricing, latency, reliability
-- Differentiate models by reasoning strength vs generation speed
-- Record model-specific prompt adaptation patterns
-- Design a lightweight routing logic for task-type-to-model mapping
-- Enable reviewer prompts to assess model output reliability
-- Plan for multi-model evaluation loops (e.g., Grok + Claude + GPT-4o)
-- Begin evaluation logging for performance and failures
+Design and maintain a system for **selecting, routing, and evaluating large language models (LLMs)** based on task type, reasoning ability, access methods, costs, reliability, and user-defined preferences.
 
 ---
 
-## 🧠 Key Ideas to Track
+## 🔹 Key Goals
 
-- Reasoning models vs generative models: how to choose
-- Structured vs unstructured prompt input
-- Task classification: research, summarization, synthesis, validation
-- Local quantized model usage and constraints (e.g., llama.cpp, Ollama)
-- Router design: file-based input → task → model(s) → reviewer loop
-- Use of assistant-agent separation (router, reviewer, executor)
-- Explore how to collect model performance data over time
-- Evaluate when to use search vs static LLM
-- Decision trees, scorecards, or rule-sets for model choice
-
----
-
-## 🧪 Suggested Experiments
-
-- Run identical prompts across GPT-4o, Claude Opus, Gemini Pro
-- Use reviewer prompt to evaluate each output
-- Compare search-enabled vs search-disabled runs
-- Benchmark against latency, reasoning quality, hallucination frequency
+- Create a structured **catalog of available LLMs** (hosted + local)
+- Track model capabilities: reasoning, generation, summarization, speed, latency
+- Track access methods: OpenAI, Claude, Gemini, Grok, local APIs, etc.
+- Document prompt adaptation needs for different models
+- Develop a model selection and routing logic (manual + automated)
+- Enable task-based model decision-making using clear rules
+- Design **reviewer prompts** to evaluate model output reliability and completeness
+- Implement multi-model feedback loops: compare answers, escalate, route to reviewer
+- Prepare for eventual automation and integration into assistant/agent systems
 
 ---
 
-## 📥 Tasks (Initial)
+## 🔹 Core Components
 
-- [ ] Create `models.md` for cataloging available LLMs
-- [ ] Add `routing-strategy.md` to outline logic by task type
-- [ ] Prepare reviewer prompt set in `reviewer-prompts.md`
-- [ ] Design and test a selection prompt (e.g., “Which model should I use for X?”)
+### 1. Model Capability Tracker
+
+- Name, provider, access type (API/local), rate limits, cost structure
+- Token/window limits, search capability, file input support
+- Update history, reliability patterns, reasoning depth classification
+
+### 2. Routing Logic
+
+- Task-to-model mapping table or logic flow
+- Conditional decision-making (e.g., if search needed, use X; if local, use Y)
+- Model fallback based on latency, token limits, or quota status
+
+### 3. Reviewer Agent
+
+- Prompt templates for reviewing output quality, coherence, hallucination risk
+- Scoring guidelines and structured review format
+- Cross-model comparison prompts
+
+### 4. Prompt Adaptation Patterns
+
+- Variants needed for models that require different formatting (e.g., Claude XML tags)
+- Self-evaluation trigger prompts ("explain how you understood this before answering")
+- Structure tags or reusable prompt components
+
+### 5. Evaluation Workflows
+
+- Run same prompt across multiple models
+- Capture outputs + reviewer evaluation
+- Score responses on reasoning, hallucination risk, formatting, insight quality
+
+### 6. Task Classifier (Future)
+
+- Classify user requests into task types: research, summarization, validation, generation
+- Use classification to trigger routing decisions
 
 ---
 
-> You can move any of these items into GitHub Issues or Projects if needed. This backlog will grow as other repos are integrated.
+## 🔹 Roles & Agents
+
+- **User/Initiator**: Provides task intent and constraints
+- **Router**: Maps task to appropriate model(s)
+- **LLM Worker**: Generates or retrieves answer
+- **Reviewer**: Evaluates and flags weak or incorrect outputs
+- **Decision Layer**: Chooses whether to escalate, switch models, or finalize
+
+---
+
+## 🧠 Key Insights & Strategy Notes
+
+- **Model selection is not static**: capabilities evolve rapidly, so selection logic must be easily editable
+- Reasoning models (GPT-4o, Claude Opus) often required for synthesis, logic, ambiguity
+- Generation-first models (e.g. Gemini Pro) may be better for formatting, templating, speed
+- **Reviewers are essential**: many LLMs produce superficially plausible but flawed answers
+- Model hallucination is often subtle; detecting it must be part of the process
+- **Two-way flow with agents like Copilot** is critical (copilot executes, LLMs generate)
+- **File- and folder-based context** is more scalable than prompt text alone
+- Local quantized models (e.g., via Ollama, llama.cpp) are viable but must be benchmarked
+- Cost/rate limits can be offset by chaining: cheap model for draft, powerful model for polish
+- **Grok’s search access** is uniquely valuable for community data (X/Twitter)
+- **Selection rules should be declarative**, not procedural, for reuse and automation
+
+---
+
+## 🧪 Experiments
+
+- [ ] Run identical prompts across GPT-4o, Claude, Gemini, Perplexity
+- [ ] Use reviewer prompt to evaluate each output
+- [ ] Compare same prompt with search ON/OFF in GPT-4o and Grok
+- [ ] Benchmark latency + quality for local vs API models
+- [ ] Test effectiveness of prompt explain-understanding-first strategy
+- [ ] Run prompts through a scoring reviewer and compare with human rating
+- [ ] Record false-positive hallucination cases and model failure patterns
+
+---
+
+## 🛠 Tasks (Open)
+
+- [ ] Create `models.md` catalog of models, metadata, rate limits, access
+- [ ] Create `routing-strategy.md` logic flow or ruleset
+- [ ] Design initial reviewer prompt in `reviewer-prompts.md`
+- [ ] Prepare a task classifier template or table
+- [ ] Define fallback rules based on quota, cost, response failure
+- [ ] Add local model testing section (llama.cpp, Mistral, Ollama)
+- [ ] Integrate results from Grok search when collecting model performance signals
+
+---
+
+## 📌 Notes
+
+- This backlog grows **continuously**
+- All new ideas must be logged here, even if later moved to GitHub Issues
+- Do **not** trim or remove ideas unless explicitly archived elsewhere
+- This is the **single source of truth** for everything related to LLM selection strategy
+
+---
+
+> End of file.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# PROJECT BACKLOG — llm-selection
+
+This project aims to support strategic model selection for LLM tasks. It will track model capabilities, reasoning depth, rate limits, file support, access type (API/local), and usage strategies.
+
+---
+
+## ✅ Core Goals
+
+- Catalog available models (GPT-4o, Claude, Gemini, Perplexity, local models)
+- Track API access methods, rate limits, pricing, latency, reliability
+- Differentiate models by reasoning strength vs generation speed
+- Record model-specific prompt adaptation patterns
+- Design a lightweight routing logic for task-type-to-model mapping
+- Enable reviewer prompts to assess model output reliability
+- Plan for multi-model evaluation loops (e.g., Grok + Claude + GPT-4o)
+- Begin evaluation logging for performance and failures
+
+---
+
+## 🧠 Key Ideas to Track
+
+- Reasoning models vs generative models: how to choose
+- Structured vs unstructured prompt input
+- Task classification: research, summarization, synthesis, validation
+- Local quantized model usage and constraints (e.g., llama.cpp, Ollama)
+- Router design: file-based input → task → model(s) → reviewer loop
+- Use of assistant-agent separation (router, reviewer, executor)
+- Explore how to collect model performance data over time
+- Evaluate when to use search vs static LLM
+- Decision trees, scorecards, or rule-sets for model choice
+
+---
+
+## 🧪 Suggested Experiments
+
+- Run identical prompts across GPT-4o, Claude Opus, Gemini Pro
+- Use reviewer prompt to evaluate each output
+- Compare search-enabled vs search-disabled runs
+- Benchmark against latency, reasoning quality, hallucination frequency
+
+---
+
+## 📥 Tasks (Initial)
+
+- [ ] Create `models.md` for cataloging available LLMs
+- [ ] Add `routing-strategy.md` to outline logic by task type
+- [ ] Prepare reviewer prompt set in `reviewer-prompts.md`
+- [ ] Design and test a selection prompt (e.g., “Which model should I use for X?”)
+
+---
+
+> You can move any of these items into GitHub Issues or Projects if needed. This backlog will grow as other repos are integrated.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,42 @@ This project is designed to help you make strategic model selection decisions fo
 - [ ] Prepare reviewer prompt set in `reviewer-prompts.md`
 - [ ] Design and test a selection prompt (e.g., "Which model should I use for X?")
 
+## 📊 Roadmap & Prioritization
+
+### Phase 1: Model Cataloging (June 2025)
+
+- **Focus**: Comprehensive model inventory and capability assessment
+- **Deliverable**: `models.md` with detailed capability matrix
+- **Key milestones**: 
+  - Complete API documentation for all major providers
+  - Document token limits and rate restrictions
+  - Create standardized capability scoring system
+
+### Phase 2: Routing Strategy (July 2025)
+
+- **Focus**: Decision framework for model selection
+- **Deliverable**: `routing-strategy.md` with decision trees
+- **Key milestones**:
+  - Map task types to optimal model profiles
+  - Create fallback pathways for rate limits and failures
+  - Design cost optimization strategies
+
+### Phase 3: Evaluation Framework (August 2025)
+
+- **Focus**: Output quality assessment
+- **Deliverable**: `reviewer-prompts.md` with scoring metrics
+- **Key milestones**:
+  - Develop standardized evaluation criteria
+  - Create reviewer prompts for different output types
+  - Build comparison methodology for cross-model evaluation
+
+### Success Metrics
+
+- **Latency targets**: <500ms for routing decisions, <5s end-to-end for simple tasks
+- **Hallucination thresholds**: <2% factual errors in final outputs
+- **Cost efficiency**: 30% reduction in token usage vs. single-model approach
+- **Selection accuracy**: >95% appropriate model selection for given task types
+
 ## 📖 Detailed Documentation
 
 For complete project details including:

--- a/README.md
+++ b/README.md
@@ -1,52 +1,45 @@
-# LLM Selection Project PROJECT BACKLOG — llm-selection
+# LLM Selection Project
 
-This project aims to support strategic model selection for LLM tasks. It will track model capabilities, reasoning depth, rate limits, file support, access type (API/local), and usage strategies.
+A system for selecting, routing, and evaluating large language models (LLMs) based on task type, reasoning ability, access methods, costs, and reliability.
 
----
+## 🚀 Getting Started
 
-## ✅ Core Goals
+This project is designed to help you make strategic model selection decisions for your LLM tasks. The repository will grow to include:
 
-- Catalog available models (GPT-4o, Claude, Gemini, Perplexity, local models)
-- Track API access methods, rate limits, pricing, latency, reliability
-- Differentiate models by reasoning strength vs generation speed
-- Record model-specific prompt adaptation patterns
-- Design a lightweight routing logic for task-type-to-model mapping
-- Enable reviewer prompts to assess model output reliability
-- Plan for multi-model evaluation loops (e.g., Grok + Claude + GPT-4o)
-- Begin evaluation logging for performance and failures
+- Model catalogs with capability tracking
+- Routing logic for task-to-model mapping
+- Evaluation tools and reviewer prompts
+- Integration patterns for various LLM access methods
 
----
+## 📂 Repository Structure
 
-## 🧠 Key Ideas to Track
+- `models.md` - Catalog of available LLMs and their capabilities (planned)
+- `routing-strategy.md` - Logic for matching tasks to models (planned)
+- `reviewer-prompts.md` - Evaluation criteria and prompts (planned)
+- `PROJECT_BACKLOG.md` - Complete project backlog with detailed goals and plans
 
-- Reasoning models vs generative models: how to choose
-- Structured vs unstructured prompt input
-- Task classification: research, summarization, synthesis, validation
-- Local quantized model usage and constraints (e.g., llama.cpp, Ollama)
-- Router design: file-based input → task → model(s) → reviewer loop
-- Use of assistant-agent separation (router, reviewer, executor)
-- Explore how to collect model performance data over time
-- Evaluate when to use search vs static LLM
-- Decision trees, scorecards, or rule-sets for model choice
-
----
-
-## 🧪 Suggested Experiments
-
-- Run identical prompts across GPT-4o, Claude Opus, Gemini Pro
-- Use reviewer prompt to evaluate each output
-- Compare search-enabled vs search-disabled runs
-- Benchmark against latency, reasoning quality, hallucination frequency
-
----
-
-## 📥 Tasks (Initial)
+## 🏁 Initial Tasks
 
 - [ ] Create `models.md` for cataloging available LLMs
 - [ ] Add `routing-strategy.md` to outline logic by task type
 - [ ] Prepare reviewer prompt set in `reviewer-prompts.md`
-- [ ] Design and test a selection prompt (e.g., “Which model should I use for X?”)
+- [ ] Design and test a selection prompt (e.g., "Which model should I use for X?")
+
+## 📖 Detailed Documentation
+
+For complete project details including:
+
+- Core components
+- Key insights and strategy notes
+- Planned experiments
+- Roles and agents
+
+Please refer to the [PROJECT_BACKLOG.md](PROJECT_BACKLOG.md) file.
+
+## 🤝 Contributing
+
+Contributions are welcome! Check the PROJECT_BACKLOG.md for areas where you can help, or suggest new features and improvements.
 
 ---
 
-> You can move any of these items into GitHub Issues or Projects if needed. This backlog will grow as other repos are integrated.
+> Note: This project is in active development. Features and documentation will evolve over time.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PROJECT BACKLOG — llm-selection
+# LLM Selection Project PROJECT BACKLOG — llm-selection
 
 This project aims to support strategic model selection for LLM tasks. It will track model capabilities, reasoning depth, rate limits, file support, access type (API/local), and usage strategies.
 


### PR DESCRIPTION
Establish a comprehensive backlog for the LLM selection project, enhancing clarity and detail on goals, key ideas, and suggested experiments. This backlog serves as a strategic record to guide model selection and evaluation processes.

## Summary by Sourcery

Introduce a comprehensive project backlog and roadmap for LLM selection strategy to guide model cataloging, routing logic, evaluation workflows, and experiments.

Documentation:
- Add PROJECT_BACKLOG.md detailing project purpose, key goals, core components, roles, strategy insights, experiments, open tasks, and governance notes.
- Add README.md summarizing core goals, key ideas, suggested experiments, and initial tasks for the llm-selection project.

Chores:
- Establish initial planning artifacts and living backlog framework to drive model selection, routing, and evaluation processes.